### PR TITLE
Add Discord webhook support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can make your own boundary GeoJSONs with https://geoman.io/geojson-editor.
 |`--image-width`|Maximum width of image in pixels for `text+map` output format (default 512).|
 |`--facebook-token`|Facebook Messenger/Workplace token (must have _Message Any Member_ and _Group Chat Bot_ permissions).||
 |`--facebook-thread`|Facebook Messenger/Workplace Thread ID to post in. Cannot be a single user chat.||
+|`--discord-webhook-url`|Discord webhook URL to use to post messages.||
 
 ## Logs
 

--- a/src/discord.rs
+++ b/src/discord.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+use color_eyre::eyre::{eyre, Result};
+use reqwest::{
+	multipart::{Form, Part},
+	Client,
+};
+use serde::Serialize;
+use serde_json::Value;
+use tracing::trace;
+
+use crate::output::{split_long_message, Out};
+
+pub async fn send(webhook_url: &str, out: &Out) -> Result<()> {
+	let mut out = if let Out {
+		message,
+		image: Some(img),
+	} = out
+	{
+		let image_only = Out {
+			message: "".into(),
+			image: Some(img.clone()),
+		};
+		send_message(webhook_url, &image_only).await?;
+		Out {
+			message: message.clone(),
+			image: None,
+		}
+	} else {
+		out.clone()
+	};
+
+	loop {
+		let (first, rest) = split_long_message(out, 2000, 280);
+		send_message(webhook_url, &first).await?;
+		out = match rest {
+			Some(o) => o,
+			None => break,
+		};
+	}
+
+	Ok(())
+}
+
+async fn send_message(webhook_url: &str, out: &Out) -> Result<()> {
+	let client = Client::new();
+	let req = client.post(webhook_url);
+
+	let req = if let Some(ref imagedata) = out.image {
+		assert!(out.message.is_empty(), "cannot send both text and an image");
+
+		let part = Part::bytes(imagedata.clone())
+			.file_name("image.png")
+			.mime_str("image/png")?;
+		let form = Form::new().part("file", part);
+
+		req.multipart(form)
+	} else {
+		req.header("Content-Type", "application/json")
+			.json(&Payload {
+				content: out.message.clone(),
+				..Default::default()
+			})
+	};
+
+	trace!(?req, "sending request");
+	let resp = req.send().await?;
+	trace!(?resp, "response from discord");
+	let status = resp.status();
+
+	let body: HashMap<String, Value> = resp.json().await?;
+	trace!(?body, "response body");
+
+	if !status.is_success() {
+		Err(eyre!(
+			"failed to send message to discord: {}\n{:?}",
+			status,
+			body
+		))
+	} else {
+		Ok(())
+	}
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+struct Payload {
+	#[serde(skip_serializing_if = "String::is_empty")]
+	content: String,
+
+	#[serde(skip_serializing_if = "String::is_empty")]
+	username: String,
+
+	#[serde(skip_serializing_if = "String::is_empty")]
+	avatar_url: String,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use output::OutputFormat;
 use crate::output::Out;
 
 mod cap;
+mod discord;
 mod facebook;
 mod feed;
 mod geodirs;
@@ -84,6 +85,10 @@ pub struct Args {
 	/// This cannot be a single user chat, and the bot must already be in the group/thread.
 	#[structopt(long)]
 	facebook_thread: Option<String>,
+
+	/// Discord webhook URL to use to post messages.
+	#[structopt(long)]
+	discord_webhook_url: Option<String>,
 }
 
 #[tokio::main]
@@ -194,6 +199,12 @@ async fn main() -> Result<()> {
 		info!(%thread, "sending to workplace");
 		facebook::send(token, thread, &out).await?;
 		debug!(%thread, "sent to workplace");
+	}
+
+	if let Some(webhook_url) = &args.discord_webhook_url {
+		info!("sending to discord");
+		discord::send(webhook_url, &out).await?;
+		debug!("sent to discord");
 	}
 
 	info!("all done");


### PR DESCRIPTION
This implementation is very much based on the Facebook Workplace implementation in `src/facebook.rs`, modified just enough to make it work. As such, it posts the image as a separate message, even though Discord webhooks totally support images as attachments to a message - this could definitely be cleaned up at a later point!